### PR TITLE
Fix BIP148 code.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1852,10 +1852,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // mandatory segwit activation between Oct 1st 2017 and Nov 15th 2017 inclusive
-    if (pindex->GetMedianTimePast() >= 1506816000 && pindex->GetMedianTimePast() <= 1510704000 && !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) {
-      if (!((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) && (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0) {
+    if (pindex->GetMedianTimePast() >= 1506816000 &&                          // Sun Oct  1 00:00:00 UTC 2017
+        pindex->GetMedianTimePast() <= 1510704000 &&                          // Wed Nov 15 00:00:00 UTC 2017
+        !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()) &&       // segwit not activated yet
+        ((pindex->nVersion & VERSIONBITS_TOP_MASK) != VERSIONBITS_TOP_BITS || // no BIP9 or no segwit
+         (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) == 0)) {
         return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
-      }
     }
 
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;


### PR DESCRIPTION
The BIP148 code as it stands won't reject any non-segwit-signalling blocks unless they also don't use BIP9 at all. See [my comment in the BIP repository](https://github.com/bitcoin/bips/commit/cc67ae995c4df0b0e1040c34f8f68848954de35a#commitcomment-21490012) for details.