### PR TITLE
Revert whitespace change to reduce diff size.

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -82,8 +82,8 @@ std::string FormatFullVersion()
     return CLIENT_BUILD;
 }
 
-/**
- * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki)
+/** 
+ * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) 
  */
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
 {


### PR DESCRIPTION
We should try to keep the difference between Core's 0.14 branch and here as small as possible. Randomly deleting spaces goes against that idea.

With this pull request the total diff becomes just this:

    diff --git a/src/clientversion.cpp b/src/clientversion.cpp
    index d2344de..61be7f3 100644
    --- a/src/clientversion.cpp
    +++ b/src/clientversion.cpp
    @@ -98,6 +98,6 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const
                 ss << "; " << *it;
             ss << ")";
         }
    -    ss << "/";
    +    ss << "/UASF-Segwit:0/";
         return ss.str();
     }
    diff --git a/src/validation.cpp b/src/validation.cpp
    index e8a3736..ea48f1f 100644
    --- a/src/validation.cpp
    +++ b/src/validation.cpp
    @@ -1851,6 +1851,15 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             flags |= SCRIPT_VERIFY_NULLDUMMY;
         }
     
    +    // mandatory segwit activation between Oct 1st 2017 and Nov 15th 2017 inclusive
    +    if (pindex->GetMedianTimePast() >= 1506816000 &&                          // Sun Oct  1 00:00:00 UTC 2017
    +        pindex->GetMedianTimePast() <= 1510704000 &&                          // Wed Nov 15 00:00:00 UTC 2017
    +        !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()) &&       // segwit not activated yet
    +        ((pindex->nVersion & VERSIONBITS_TOP_MASK) != VERSIONBITS_TOP_BITS || // no BIP9 or no segwit
    +         (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) == 0)) {
    +        return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
    +    }
    +
         int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
         LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);
     
