### PR TITLE
Uasf in ua

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -98,6 +98,6 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
             ss << "; " << *it;
         ss << ")";
     }
-    ss << "/UASF-Segwit:0/";
+    ss << "/";
     return ss.str();
 }

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_CLIENTVERSION_H
 #define BITCOIN_CLIENTVERSION_H
 
+#define CLIENT_VERSION_UA "UASF-Segwit 0.1"
+
 #if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
 #else

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1234,6 +1234,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
     uacomments.push_back(CLIENT_VERSION_UA);
+    uacomments.push_back("BIP148");
     strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments);
     if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1233,6 +1233,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             uacomments.push_back(cmt);
         }
     }
+    uacomments.push_back(CLIENT_VERSION_UA);
     strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments);
     if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),


### PR DESCRIPTION
How about this as an alternative fix for #4?

This makes the 'subver' appear like this:

    /Satoshi:0.14.0(UASF-Segwit 0.1)/