### PR TITLE
new bip148 specification

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -100,6 +100,6 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     }
     ss << "/";
     if (!fBaseNameOnly)
-        ss << "UASF-Segwit:0.1.1(BIP148)/";
+        ss << "UASF-Segwit:0.1.2(BIP148)/";
     return ss.str();
 }

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -100,6 +100,6 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     }
     ss << "/";
     if (!fBaseNameOnly)
-        ss << "UASF-Segwit:0.1.2(BIP148)/";
+        ss << "UASF-Segwit:0.2(BIP148)/";
     return ss.str();
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1851,13 +1851,16 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_NULLDUMMY;
     }
 
-    // mandatory segwit activation between Oct 1st 2017 and Nov 15th 2017 inclusive
-    if (pindex->GetMedianTimePast() >= 1506816000 &&                          // Sun Oct  1 00:00:00 UTC 2017
-        pindex->GetMedianTimePast() <= 1510704000 &&                          // Wed Nov 15 00:00:00 UTC 2017
-        !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()) &&       // segwit not activated yet
-        ((pindex->nVersion & VERSIONBITS_TOP_MASK) != VERSIONBITS_TOP_BITS || // no BIP9 or no segwit
-         (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) == 0)) {
-        return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
+    // BIP148 mandatory segwit signalling.
+    if (pindex->GetMedianTimePast() >= 1501545600 && // Tue 1 Aug 2017 00:00:00 UTC
+        pindex->GetMedianTimePast() <= 1510704000 && // Wed 15 Nov 2017 00:00:00 UTC
+        !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()))
+    {
+        // versionbits topbit and segwit flag must be set.
+        if ((pindex->nVersion & VERSIONBITS_TOP_MASK) != VERSIONBITS_TOP_BITS ||
+            (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) == 0) {
+            return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
+        }
     }
 
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;


### PR DESCRIPTION
Updates code to [new specification](https://github.com/bitcoin/bips/blob/master/bip-0148.mediawiki#specification) (UASF activation on 1st August, not 1st October) as discussed in #11.