### PR TITLE
Add a -bip148 option

### DIFF
--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -451,6 +451,9 @@ Set maximum size of high\-priority/low\-fee transactions in bytes
 .IP
 Set lowest fee rate (in BTC/kB) for transactions to be included in block
 creation. (default: 0.00001)
+\fB\-bip148\fR
+.IP
+Enable BIP148 enforcement
 .PP
 RPC server options:
 .HP

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -456,6 +456,9 @@ Set maximum size of high\-priority/low\-fee transactions in bytes
 .IP
 Set lowest fee rate (in BTC/kB) for transactions to be included in block
 creation. (default: 0.00001)
+\fB\-bip148\fR
+.IP
+Enable BIP148 enforcement
 .PP
 RPC server options:
 .HP

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -482,6 +482,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-blockmaxsize=<n>", strprintf(_("Set maximum block size in bytes (default: %d)"), DEFAULT_BLOCK_MAX_SIZE));
     strUsage += HelpMessageOpt("-blockprioritysize=<n>", strprintf(_("Set maximum size of high-priority/low-fee transactions in bytes (default: %d)"), DEFAULT_BLOCK_PRIORITY_SIZE));
     strUsage += HelpMessageOpt("-blockmintxfee=<amt>", strprintf(_("Set lowest fee rate (in %s/kB) for transactions to be included in block creation. (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_BLOCK_MIN_TX_FEE)));
+    strUsage += HelpMessageOpt("-bip148", strprintf(_("Enable BIP148/UASF (default: %d)"), DEFAULT_BIP148));
     if (showDebug)
         strUsage += HelpMessageOpt("-blockversion=<n>", "Override block version to test forking scenarios");
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1851,17 +1851,19 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_NULLDUMMY;
     }
 
-    // BIP148 mandatory segwit signalling.
-    int64_t nMedianTimePast = pindex->GetMedianTimePast();
-    if ( (nMedianTimePast >= 1501545600) &&  // Tue 01 Aug 2017 00:00:00 UTC
-         (nMedianTimePast <= 1510704000) &&  // Wed 15 Nov 2017 00:00:00 UTC
-         (!IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
-          !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )   // and is not active.
-    {
-        bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS;
-        bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0;
-        if (!(fVersionBits && fSegbit)) {
-            return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
+    if (GetBoolArg("-bip148", DEFAULT_BIP148)) {
+        // BIP148 mandatory segwit signalling.
+        int64_t nMedianTimePast = pindex->GetMedianTimePast();
+        if ( (nMedianTimePast >= 1501545600) &&  // Tue 01 Aug 2017 00:00:00 UTC
+             (nMedianTimePast <= 1510704000) &&  // Wed 15 Nov 2017 00:00:00 UTC
+             (!IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
+              !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) )   // and is not active.
+        {
+            bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS;
+            bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0;
+            if (!(fVersionBits && fSegbit)) {
+                return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
+            }
         }
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -75,6 +75,8 @@ static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for rev?????.dat files (since 0.8) */
 static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
+/** Default for -bip148 enforcement */
+static const unsigned int DEFAULT_BIP148 = false;
 
 /** Maximum number of script-checking threads allowed */
 static const int MAX_SCRIPTCHECK_THREADS = 16;

--- a/src/validation.h
+++ b/src/validation.h
@@ -76,7 +76,7 @@ static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for rev?????.dat files (since 0.8) */
 static const unsigned int UNDOFILE_CHUNK_SIZE = 0x100000; // 1 MiB
 /** Default for -bip148 enforcement */
-static const unsigned int DEFAULT_BIP148 = false;
+static const unsigned int DEFAULT_BIP148 = true;
 
 /** Maximum number of script-checking threads allowed */
 static const int MAX_SCRIPTCHECK_THREADS = 16;


### PR DESCRIPTION
This minimises the code differences vs Core when it eventually gets merged there.

Additionally, once this and the other PRs get merged here, it will be possible to run the BIP148 functional test.

This should be merged before #22 or #24