### PR TITLE
Signal UASF only when bip148=1

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -5,6 +5,8 @@
 #include "clientversion.h"
 
 #include "tinyformat.h"
+#include "util.h"
+#include "validation.h"
 
 #include <string>
 
@@ -99,7 +101,7 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
         ss << ")";
     }
     ss << "/";
-    if (!fBaseNameOnly)
+    if (!fBaseNameOnly && GetBoolArg("-bip148", DEFAULT_BIP148))
         ss << "UASF-Segwit:0.3(BIP148)/";
     return ss.str();
 }


### PR DESCRIPTION
UASF/BIP148 should be signaled only when it's actually being enforced