### PR TITLE
Enforce segsignal's rules at its activation height

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -156,6 +156,7 @@ testScripts = [
     'rpcnamedargs.py',
     'listsinceblock.py',
     'p2p-leaktests.py',
+    'segsignal.py',
 ]
 if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')

--- a/qa/rpc-tests/segsignal.py
+++ b/qa/rpc-tests/segsignal.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
+from test_framework.blocktools import create_coinbase, create_block
+
+class SegsignalUASFTest(ComparisonTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
+        self.height = 1  # height of the next block to build
+        self.last_block_time = int(time.time())
+
+        # Mine 1439 non segwit blocks
+        self.generate_blocks(1439, 0x20000000)
+
+        # Check that segwit is still started
+        assert_equal(self.get_bip9_status('segwit')['status'], 'started')
+
+        # Mine a non-segwit block. this should be rejected
+        self.generate_blocks(1, 0x20000000, 'bad-no-segwit')
+
+        # Now mine a segwit block. this should not be rejected
+        self.generate_blocks(1, 0x20000002)
+
+        # Mine another non-segwit block, this should be rejected
+        self.generate_blocks(1, 0x20000000, 'bad-no-segwit')
+
+        # Mine 143 more blocks. should still be started
+        print(self.nodes[0].getblockchaininfo())
+        self.generate_blocks(142, 0x20000002)
+        assert_equal(self.get_bip9_status('segwit')['status'], 'started')
+
+        # Mine 1 more block, should now be locked in
+        self.generate_blocks(1, 0x20000002)
+        print(self.nodes[0].getblockchaininfo())
+        assert_equal(self.get_bip9_status('segwit')['status'], 'locked_in')
+
+        # Mine a non-segwit block, should be accepted
+        self.generate_blocks(1, 0x20000000)
+
+    def generate_blocks(self, number, version, error = None):
+        for i in range(number):
+            block = create_block(self.tip, create_coinbase(self.height), self.last_block_time + 1)
+            block.nVersion = version
+            block.rehash()
+            block.solve()
+            assert_equal(self.nodes[0].submitblock(bytes_to_hex_str(block.serialize())), error)
+            if (error == None):
+                self.last_block_time += 1
+                self.tip = block.sha256
+                self.height += 1
+
+    def get_bip9_status(self, key):
+        info = self.nodes[0].getblockchaininfo()
+        return info['bip9_softforks'][key]
+
+
+if __name__ == '__main__':
+    SegsignalUASFTest().main()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,6 +75,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.BIP91Height = 477120;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -179,6 +180,7 @@ public:
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+        consensus.BIP91Height = 100000000; // This doesn't matter because segwit has already activated on testnet
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -268,6 +270,7 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.BIP91Height = 100000000;
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -366,4 +369,3 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 {
     regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout);
 }
- 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -270,7 +270,7 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
-        consensus.BIP91Height = 100000000;
+        consensus.BIP91Height = 1440; // BIP91 Activated on regtest (used in rpc activation tests)
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -46,6 +46,8 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
+    /** Block height at which BIP91 becomes active */
+    int BIP91Height;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1858,6 +1858,17 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         }
     }
 
+    // SEGSIGNAL mandatory segwit signalling.
+    if (pindex->nHeight >= chainparams.GetConsensus().BIP91Height &&
+        VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT,    versionbitscache) == THRESHOLD_STARTED)
+    {
+        bool fVersionBits = (pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS;
+        bool fSegbit = (pindex->nVersion & VersionBitsMask(chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT)) != 0;
+        if (!(fVersionBits && fSegbit)) {
+            return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
+        }
+    }
+
     int64_t nTime2 = GetTimeMicros(); nTimeForks += nTime2 - nTime1;
     LogPrint("bench", "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);
 


### PR DESCRIPTION
This is https://github.com/bitcoin/bitcoin/pull/10900 but on the 0.14-BIP148 branch of this repo.

This change will enforce BIP 91's rule of mandatory segwit signaling at BIP 91's activation height of 477120 blocks.