### PR TITLE
Backport: Disconnect network service bits 6 and 8 until Aug 1, 2018

### DIFF
--- a/qa/rpc-tests/p2p-leaktests.py
+++ b/qa/rpc-tests/p2p-leaktests.py
@@ -2,20 +2,21 @@
 # Copyright (c) 2017 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-
-'''
-Test for message sending before handshake completion
+"""Test for message sending before handshake completion
 
 A node should never send anything other than VERSION/VERACK/REJECT until it's
 received a VERACK.
 
 This test connects to a node and sends it a few messages, trying to intice it
 into sending us something it shouldn't.
-'''
+
+Also test that nodes that send unsupported service bits to bitcoind are disconnected
+and don't receive a VERACK. Unsupported service bits are currently 1 << 5 and
+1 << 7 (until August 1st 2018)."""
+
+from test_framework.mininode import *
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
 
 banscore = 10
 
@@ -112,18 +113,27 @@ class P2PLeakTest(BitcoinTestFramework):
         no_version_bannode = CNodeNoVersionBan()
         no_version_idlenode = CNodeNoVersionIdle()
         no_verack_idlenode = CNodeNoVerackIdle()
+        unsupported_service_bit5_node = CLazyNode()
+        unsupported_service_bit7_node = CLazyNode()
 
+        self.nodes[0].setmocktime(1501545600)  # August 1st 2017
         connections = []
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_bannode, send_version=False))
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_version_idlenode, send_version=False))
         connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], no_verack_idlenode))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], unsupported_service_bit5_node, services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_5))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], unsupported_service_bit7_node, services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_7))
         no_version_bannode.add_connection(connections[0])
         no_version_idlenode.add_connection(connections[1])
         no_verack_idlenode.add_connection(connections[2])
+        unsupported_service_bit5_node.add_connection(connections[3])
+        unsupported_service_bit7_node.add_connection(connections[4])
 
         NetworkThread().start()  # Start up network handling in another thread
 
         assert(wait_until(lambda: no_version_bannode.connected and no_version_idlenode.connected and no_verack_idlenode.version_received, timeout=10))
+        assert wait_until(lambda: unsupported_service_bit5_node.ever_connected, timeout=10)
+        assert wait_until(lambda: unsupported_service_bit7_node.ever_connected, timeout=10)
 
         # Mine a block and make sure that it's not sent to the connected nodes
         self.nodes[0].generate(1)
@@ -134,12 +144,32 @@ class P2PLeakTest(BitcoinTestFramework):
         #This node should have been banned
         assert(no_version_bannode.connection.state == "closed")
 
+        # These nodes should have been disconnected
+        assert not unsupported_service_bit5_node.connected
+        assert not unsupported_service_bit7_node.connected
+
         [conn.disconnect_node() for conn in connections]
 
         # Make sure no unexpected messages came in
         assert(no_version_bannode.unexpected_msg == False)
         assert(no_version_idlenode.unexpected_msg == False)
         assert(no_verack_idlenode.unexpected_msg == False)
+        assert not unsupported_service_bit5_node.unexpected_msg
+        assert not unsupported_service_bit7_node.unexpected_msg
+
+        self.log.info("Service bits 5 and 7 are allowed after August 1st 2018")
+        self.nodes[0].setmocktime(1533168000)  # August 2nd 2018
+
+        allowed_service_bit5_node = NodeConnCB()
+        allowed_service_bit7_node = NodeConnCB()
+
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], allowed_service_bit5_node, services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_5))
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], allowed_service_bit7_node, services=NODE_NETWORK|NODE_UNSUPPORTED_SERVICE_BIT_7))
+        allowed_service_bit5_node.add_connection(connections[5])
+        allowed_service_bit7_node.add_connection(connections[6])
+
+        assert wait_until(lambda: allowed_service_bit5_node.message_count["verack"], timeout=10)
+        assert wait_until(lambda: allowed_service_bit7_node.message_count["verack"], timeout=10)
 
 if __name__ == '__main__':
     P2PLeakTest().main()

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -52,6 +52,8 @@ NODE_NETWORK = (1 << 0)
 NODE_GETUTXO = (1 << 1)
 NODE_BLOOM = (1 << 2)
 NODE_WITNESS = (1 << 3)
+NODE_UNSUPPORTED_SERVICE_BIT_5 = (1 << 5)
+NODE_UNSUPPORTED_SERVICE_BIT_7 = (1 << 7)
 
 # Keep our own socket map for asyncore, so that we can track disconnects
 # ourselves (to workaround an issue with closing an asyncore socket when

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -103,9 +103,9 @@ std::string FormatSubVersion(const std::string& name, int nClientVersion, const 
     ss << "/";
     if (!fBaseNameOnly) {
         if (GetBoolArg("-bip148", DEFAULT_BIP148))
-            ss << "UASF-Segwit:1.0(BIP148)/";
+            ss << "UASF-Segwit:1.0(BIP148)/No-Central-Authority/";
         else
-            ss << "UASF-Segwit:1.0(!BIP148)/";
+            ss << "UASF-Segwit:1.0(!BIP148)/No-Central-Authority/";
     }
     return ss.str();
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1284,6 +1284,17 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             return false;
         }
 
+        if (nServices & ((1 << 7) | (1 << 5))) {
+            if (GetTime() < 1533096000) {
+                // Immediately disconnect peers that use service bits 6 or 8 until August 1st, 2018
+                // These bits have been used as a flag to indicate that a node is running incompatible
+                // consensus rules instead of changing the network magic, so we're stuck disconnecting
+                // based on these service bits, at least for a while.
+                pfrom->fDisconnect = true;
+                return false;
+            }
+        }
+
         if (nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version


### PR DESCRIPTION
Backport of "Disconnect network service bits 6 and 8 until Aug 1, 2018" 
 - https://github.com/bitcoin/bitcoin/pull/10982

Backport of "[tests] Test disconnecting unsupported service bits logic." - https://github.com/bitcoin/bitcoin/pull/11001

Addition of "No-Central-Authority" to the version string to indicate non-support for the New York Agreement (NYA).
